### PR TITLE
fix gevent.coros import error

### DIFF
--- a/bbqsql/lib/technique.py
+++ b/bbqsql/lib/technique.py
@@ -5,8 +5,8 @@ from bbqsql import utilities
 
 import gevent
 from gevent.event import AsyncResult,Event
-from gevent.coros import Semaphore
 from gevent.queue import Queue
+from gevent.lock import Semaphore
 from gevent.pool import Pool
 
 from time import time


### PR DESCRIPTION
newer versions of gevent does'nt have Semaphore in gevent.coros anymore.

This will result in error:

ImportError: No module named coros

this patch will change the import of Semaphore to gevent.lock which fixes this problem.