### PR TITLE
Semaphore import error fixing

### DIFF
--- a/bbqsql/lib/technique.py
+++ b/bbqsql/lib/technique.py
@@ -5,7 +5,11 @@ from bbqsql import utilities
 
 import gevent
 from gevent.event import AsyncResult,Event
-from gevent.coros import Semaphore
+try:
+    from gevent.coros import Semaphore
+except ImportError:
+    from gevent.lock import Semaphore
+
 from gevent.queue import Queue
 from gevent.pool import Pool
 


### PR DESCRIPTION
newer versions of gevent does'nt have Semaphore in gevent.coros anymore and move it in gevent.lock.
So i added an import error exception to handle this situation.